### PR TITLE
added audio toggle on ios

### DIFF
--- a/ios/RNInCallManager/RNInCallManager.m
+++ b/ios/RNInCallManager/RNInCallManager.m
@@ -236,46 +236,45 @@ RCT_EXPORT_METHOD(setKeepScreenOn:(BOOL)enable)
 
 RCT_EXPORT_METHOD(setSpeakerphoneOn:(BOOL)enable)
 {
-     BOOL success;
-     NSError *error = nil;
-	 NSArray* routes = [_audioSession availableInputs];
+    BOOL success;
+    NSError *error = nil;
+    NSArray* routes = [_audioSession availableInputs];
 
     if(!enable){
-	    NSLog(@"Is on Earpiece ");
-	    @try {
-	        success = [_audioSession setCategory:AVAudioSessionCategoryPlayAndRecord error:&error];
-	        if (!success)  NSLog(@"category not set due to",error);
-	        success = [_audioSession setMode:AVAudioSessionModeVoiceChat error:&error];
-	        if (!success)  NSLog(@"mode not set due to:%@",error);
-	        [_audioSession setPreferredOutputNumberOfChannels:0 error:nil];
-	        if (!success)  NSLog(@"port override failed due to:%@",error);
-	        [_audioSession overrideOutputAudioPort:AVAudioSessionPortBuiltInReceiver error:&error];
-	        success = [_audioSession setActive:YES error:&error];
-            if (!success) NSLog(@"audio session activation failed: %@",error);
-            else NSLog(@"audioSession override active ");
+        NSLog(@"Routing audio via Earpiece");
+        @try {
+            success = [_audioSession setCategory:AVAudioSessionCategoryPlayAndRecord error:&error];
+            if (!success)  NSLog(@"Cannot set category due to error: %@", error);
+            success = [_audioSession setMode:AVAudioSessionModeVoiceChat error:&error];
+            if (!success)  NSLog(@"Cannot set mode due to error: %@", error);
+            [_audioSession setPreferredOutputNumberOfChannels:0 error:nil];
+            if (!success)  NSLog(@"Port override failed due to: %@", error);
+            [_audioSession overrideOutputAudioPort:AVAudioSessionPortBuiltInReceiver error:&error];
+            success = [_audioSession setActive:YES error:&error];
+            if (!success) NSLog(@"Audio session activation failed: %@", error);
+            else NSLog(@"AudioSession override is successful ");
 
-        }@catch (NSException *e) {
-		    NSLog(@"thats", e.reason);
+        } @catch (NSException *e) {
+            NSLog(@"Error occurred while routing audio via Earpiece", e.reason);
         }
     } else {
-
-        NSLog(@"on LoudSpeaker");
-	    @try {
-	        NSLog(@"avaliable routes ", routes[0]);
-	        success = [_audioSession setCategory:AVAudioSessionCategoryPlayAndRecord
-				        withOptions:AVAudioSessionCategoryOptionDefaultToSpeaker
-					    error:nil];
-	        if (!success)  NSLog(@"category not set due to ",error);
-	        success = [_audioSession setMode:AVAudioSessionModeVoiceChat error:&error];
-	        if (!success)  NSLog(@"mode not set due to:%@",error);
-	        [_audioSession setPreferredOutputNumberOfChannels:0 error:nil];
-            [_audioSession overrideOutputAudioPort:AVAudioSessionPortBuiltInSpeaker error:&error];
-	        if (!success)  NSLog(@"port not ovveridden due to :%@",error);
+        NSLog(@"Routing audio via Loudspeaker");
+        @try {
+            NSLog(@"Available routes", routes[0]);
+            success = [_audioSession setCategory:AVAudioSessionCategoryPlayAndRecord
+                        withOptions:AVAudioSessionCategoryOptionDefaultToSpeaker
+                        error:nil];
+            if (!success)  NSLog(@"Cannot set category due to error: %@", error);
+            success = [_audioSession setMode:AVAudioSessionModeVoiceChat error: &error];
+            if (!success)  NSLog(@"Cannot set mode due to error: %@", error);
+            [_audioSession setPreferredOutputNumberOfChannels:0 error:nil];
+            [_audioSession overrideOutputAudioPort:AVAudioSessionPortBuiltInSpeaker error: &error];
+            if (!success)  NSLog(@"Port override failed due to: %@", error);
             success = [_audioSession setActive:YES error:&error];
-            if (!success) NSLog(@"audiosession not active due to : %@",error);
-            else NSLog(@"audioSession is active ");
-	    }@catch (NSException *e) {
-		    NSLog(@"thats", e.reason);
+            if (!success) NSLog(@"Audio session activation failed: %@", error);
+            else NSLog(@"AudioSession override is successful ");
+        } @catch (NSException *e) {
+            NSLog(@"Error occurred while routing audio via Loudspeaker", e.reason);
         }
     }
 }

--- a/ios/RNInCallManager/RNInCallManager.m
+++ b/ios/RNInCallManager/RNInCallManager.m
@@ -251,7 +251,7 @@ RCT_EXPORT_METHOD(setSpeakerphoneOn:(BOOL)enable)
             if (!success)  NSLog(@"Port override failed due to: %@", error);
             [_audioSession overrideOutputAudioPort:AVAudioSessionPortBuiltInReceiver error:&error];
             success = [_audioSession setActive:YES error:&error];
-            if (!success) NSLog(@"Audio session activation failed: %@", error);
+            if (!success) NSLog(@"Audio session override failed: %@", error);
             else NSLog(@"AudioSession override is successful ");
 
         } @catch (NSException *e) {
@@ -271,7 +271,7 @@ RCT_EXPORT_METHOD(setSpeakerphoneOn:(BOOL)enable)
             [_audioSession overrideOutputAudioPort:AVAudioSessionPortBuiltInSpeaker error: &error];
             if (!success)  NSLog(@"Port override failed due to: %@", error);
             success = [_audioSession setActive:YES error:&error];
-            if (!success) NSLog(@"Audio session activation failed: %@", error);
+            if (!success) NSLog(@"Audio session override failed: %@", error);
             else NSLog(@"AudioSession override is successful ");
         } @catch (NSException *e) {
             NSLog(@"Error occurred while routing audio via Loudspeaker", e.reason);

--- a/ios/RNInCallManager/RNInCallManager.m
+++ b/ios/RNInCallManager/RNInCallManager.m
@@ -236,7 +236,52 @@ RCT_EXPORT_METHOD(setKeepScreenOn:(BOOL)enable)
 
 RCT_EXPORT_METHOD(setSpeakerphoneOn:(BOOL)enable)
 {
-    NSLog(@"RNInCallManager.setSpeakerphoneOn(): ios doesn't support setSpeakerphoneOn()");
+    if(!enable){
+	    NSLog(@"Is on Earpiece ");
+	    @try {
+	        BOOL success;
+            NSError *error = nil;
+	        NSArray* routes = [_audioSession availableInputs];
+
+	        success = [_audioSession setCategory:AVAudioSessionCategoryPlayAndRecord error:&error];
+	        if (!success)  NSLog(@"category not set due to",error);
+	        success = [_audioSession setMode:AVAudioSessionModeVoiceChat error:&error];
+	        if (!success)  NSLog(@"mode not set due to:%@",error);
+	        [_audioSession setPreferredOutputNumberOfChannels:0 error:nil];
+	        if (!success)  NSLog(@"port override failed due to:%@",error);
+	        [_audioSession overrideOutputAudioPort:AVAudioSessionPortBuiltInReceiver error:&error];
+	        success = [_audioSession setActive:YES error:&error];
+            if (!success) NSLog(@"audio session activation failed: %@",error);
+            else NSLog(@"audioSession override active ");
+
+
+	    }@catch (NSException *e) {
+		    NSLog(@"thats", e.reason);
+        }
+    } else {
+
+        NSLog(@"on LoudSpeaker");
+	    @try {
+	        BOOL success;
+            NSError *error = nil;
+	        NSArray* routes = [_audioSession availableInputs];
+	        NSLog(@"avaliable routes ", routes[0]);
+	        success = [_audioSession setCategory:AVAudioSessionCategoryPlayAndRecord
+				        withOptions:AVAudioSessionCategoryOptionDefaultToSpeaker
+					    error:nil];
+	        if (!success)  NSLog(@"category not set due to ",error);
+	        success = [_audioSession setMode:AVAudioSessionModeVoiceChat error:&error];
+	        if (!success)  NSLog(@"mode not set due to:%@",error);
+	        [_audioSession setPreferredOutputNumberOfChannels:0 error:nil];
+            [_audioSession overrideOutputAudioPort:AVAudioSessionPortBuiltInSpeaker error:&error];
+	        if (!success)  NSLog(@"port not ovveridden due to :%@",error);
+            success = [_audioSession setActive:YES error:&error];
+            if (!success) NSLog(@"audiosession not active due to : %@",error);
+            else NSLog(@"audioSession is active ");
+	    }@catch (NSException *e) {
+		    NSLog(@"thats", e.reason);
+        }
+    }
 }
 
 RCT_EXPORT_METHOD(setForceSpeakerphoneOn:(int)flag)
@@ -716,7 +761,7 @@ RCT_EXPORT_METHOD(getIsWiredHeadsetPluggedIn:(RCTPromiseResolveBlock)resolve
     NSLog(@"RNInCallManager.startProximitySensor()");
     // _currentDevice.proximityMonitoringEnabled = YES;
     _currentDevice.proximityMonitoringEnabled = NO;
-    
+
     // --- in case it didn't deallocate when ViewDidUnload
     [self stopObserve:_proximityObserver
                  name:UIDeviceProximityStateDidChangeNotification

--- a/ios/RNInCallManager/RNInCallManager.m
+++ b/ios/RNInCallManager/RNInCallManager.m
@@ -236,13 +236,13 @@ RCT_EXPORT_METHOD(setKeepScreenOn:(BOOL)enable)
 
 RCT_EXPORT_METHOD(setSpeakerphoneOn:(BOOL)enable)
 {
+     BOOL success;
+     NSError *error = nil;
+	 NSArray* routes = [_audioSession availableInputs];
+
     if(!enable){
 	    NSLog(@"Is on Earpiece ");
 	    @try {
-	        BOOL success;
-            NSError *error = nil;
-	        NSArray* routes = [_audioSession availableInputs];
-
 	        success = [_audioSession setCategory:AVAudioSessionCategoryPlayAndRecord error:&error];
 	        if (!success)  NSLog(@"category not set due to",error);
 	        success = [_audioSession setMode:AVAudioSessionModeVoiceChat error:&error];
@@ -254,17 +254,13 @@ RCT_EXPORT_METHOD(setSpeakerphoneOn:(BOOL)enable)
             if (!success) NSLog(@"audio session activation failed: %@",error);
             else NSLog(@"audioSession override active ");
 
-
-	    }@catch (NSException *e) {
+        }@catch (NSException *e) {
 		    NSLog(@"thats", e.reason);
         }
     } else {
 
         NSLog(@"on LoudSpeaker");
 	    @try {
-	        BOOL success;
-            NSError *error = nil;
-	        NSArray* routes = [_audioSession availableInputs];
 	        NSLog(@"avaliable routes ", routes[0]);
 	        success = [_audioSession setCategory:AVAudioSessionCategoryPlayAndRecord
 				        withOptions:AVAudioSessionCategoryOptionDefaultToSpeaker

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-incall-manager",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "description": "Handling media-routes/sensors/events during a audio/video chat on React Native",
   "main": "index.js",
   "scripts": {
@@ -29,5 +29,8 @@
   "homepage": "https://github.com/zxcpoiu/react-native-incall-manager#readme",
   "peerDependencies": {
     "react-native": ">=0.40.0"
+  },
+  "publishConfig": {
+    "registry": "https://nexus.causecode.com/repository/npm-private/"
   }
 }


### PR DESCRIPTION
### Title:
User should be able to toggle the audio between earpiece and loudspeaker on ios

### Problem:
User was not able to toggle audio on ios device using `setSpeakerOnPhone` function 

### Solution:
-Used shared instance and overidden ports with `AVAudioSessionCategoryOptionDefaultToSpeaker` 
and `AVAudioSessionPortBuiltInReceiver`

### Test Procedure:
- Add this plugin to react native app
- Now audio will toggle on ios when  function `setSpeakerPhoneOn` is called 

### Checks

- [x] Each code change was executed
- [x] This code was self-reviewed once for DRYness & quality
- [x] User facing texts are checked for typos & grammar mistakes
- [x] This was tested locally on a server eg: Android, ios Emulator and Android, ios Device
